### PR TITLE
Add description to output, mark more inputs as optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add description to `assume_role_url` output.
+
+### Changed
+
+- `role_name` and `name_prefix` variables should now be marked as optional.
+
 ## [0.1.0] - 2020-03-20
 
 ### Added

--- a/main.tf
+++ b/main.tf
@@ -38,8 +38,8 @@ resource "aws_iam_policy" "policy" {
 resource "aws_iam_role" "role" {
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
   description        = "Vendor role: ${var.vendor_aws_id}"
-  name               = var.role_name == null ? null : var.role_name
-  name_prefix        = var.role_name == null ? var.name_prefix : null
+  name               = can(coalesce(var.role_name)) ? var.role_name : null
+  name_prefix        = can(coalesce(var.role_name)) ? null : try(coalesce(var.name_prefix), null)
   tags               = var.tags
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,4 @@
 output "assume_role_url" {
-  value = "https://signin.aws.amazon.com/switchrole?account=${data.aws_caller_identity.current.account_id}&roleName=${urlencode(aws_iam_role.role.name)}"
+  description = "URL to assume the newly created role in AWS."
+  value       = "https://signin.aws.amazon.com/switchrole?account=${data.aws_caller_identity.current.account_id}&roleName=${urlencode(aws_iam_role.role.name)}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -7,7 +7,7 @@ variable "mfa_max_age" {
 variable "name_prefix" {
   description = "Optional name_prefix to use for generated resources."
   type        = string
-  default     = null
+  default     = ""
 }
 
 variable "permissions" {
@@ -18,7 +18,7 @@ variable "permissions" {
 variable "role_name" {
   description = "Explicit role name for assuming."
   type        = string
-  default     = null
+  default     = ""
 }
 
 variable "tags" {


### PR DESCRIPTION
After publishing to Terraform's registry, the auto-generated docs
had two optional variables listed as required. Hopefully, this explicit
change to an empty string value will change that.

I'm not sure if there is a difference betweeen passing `null` or `""`
to the `name_prefix` so I jump through a few function hoops to directly
pass what the module caller sets.